### PR TITLE
Remove corporation status badge

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -38,16 +38,7 @@ export default function HeroSection() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
         >
-          {/* Badge */}
-          <motion.div
-            className="inline-flex items-center space-x-2 bg-gradient-to-r from-primary-100 to-secondary-100 px-4 py-2 rounded-full text-sm font-medium text-primary-700 mb-8"
-            initial={{ scale: 0 }}
-            animate={{ scale: 1 }}
-            transition={{ delay: 0.2 }}
-          >
-            <Sparkles className="w-4 h-4" />
-            <span>一般社団法人として活動中</span>
-          </motion.div>
+          {/* Badge removed per request */}
 
           {/* Main Heading */}
           <motion.h1


### PR DESCRIPTION
## Summary
- remove the text "一般社団法人として活動中" from the hero banner

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_686a75b899f88322a7c7f0acf02792d0